### PR TITLE
Use links instead of router-links

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -20,19 +20,19 @@ export default {
     navLinks: [
       {
         text: "Home",
-        path: "/home"
+        path: "/connect/home"
       },
       {
         text: "Profile",
-        path: "/profile/1"
+        path: "/connect/profile/1"
       },
       {
         text: "Search",
-        path: "/search"
+        path: "/connect/search"
       },
       {
         text: "Log In",
-        path: "/log-in"
+        path: "/connect/log-in"
       }
     ]
   })

--- a/client/src/components/NavBar.vue
+++ b/client/src/components/NavBar.vue
@@ -31,9 +31,9 @@
             v-for="(link, index) in navLinks"
             :key="index"
           >
-            <router-link :to="link.path">
+            <a :href="link.path">
               {{ link.text }}
-            </router-link>
+            </a>
           </li>
         </ul>
       </div>

--- a/client/src/components/SignIn.vue
+++ b/client/src/components/SignIn.vue
@@ -6,7 +6,7 @@
       </div>
       <form class="form">
         <div id="button">
-          <router-link to="/register" tag="b-button">Sign In</router-link>
+          <a href="/connect/register" tag="b-button">Sign In</a>
         </div>
       </form>
     </body>
@@ -23,6 +23,20 @@ export default {
 body {
   color: black;
   text-align: center;
+}
+a {
+  text-decoration: none;
+  background-color: #2e2e2e;
+  color: white;
+  padding: 10px;
+  border-radius: 7px;
+}
+
+a:hover {
+  background-color: white;
+  color: black;
+  border-color: black;
+  border-style:solid;
 }
 .brand {
   font-weight: bolder;


### PR DESCRIPTION
The router-links change the page content via javascript instead of making a GET request to the server to load the page. This means that the Web Login redirects never get triggered prompting a user to login. 

Switch to using links instead so requests are properly called and page will redirect to Web Login. 